### PR TITLE
fix: modified to use the latest terraform version

### DIFF
--- a/acceptance_tests/module_test/versions.tf
+++ b/acceptance_tests/module_test/versions.tf
@@ -9,8 +9,7 @@ terraform {
       version = "~>1.43.0"
     }
   }
-  required_version = ">=1.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">=1.3.0"
 }
 
 ##############################################################################

--- a/acceptance_tests/secondary_nic_test/versions.tf
+++ b/acceptance_tests/secondary_nic_test/versions.tf
@@ -9,8 +9,7 @@ terraform {
       version = "~>1.43.0"
     }
   }
-  required_version = ">=1.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">=1.3.0"
 }
 
 ##############################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -9,8 +9,7 @@ terraform {
       version = "~>1.43.0"
     }
   }
-  required_version = ">=1.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">=1.3.0"
 }
 
 ##############################################################################


### PR DESCRIPTION
### Description

- Optional attributes are removed in order to support latest Terraform version i.e.
   `experiments = [module_variable_optional_attrs]`
- Terraform version is updated i.e.`required_version = ">= 1.3.0"`

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [x] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
